### PR TITLE
gnu-tar: fix build for High Sierra

### DIFF
--- a/Formula/g/gnu-tar.rb
+++ b/Formula/g/gnu-tar.rb
@@ -42,6 +42,10 @@ class GnuTar < Formula
       "--without-selinux"
     end
 
+    # On High Sierra, build system complains about various _libintl_ symbols not found,
+    # despite configure checking for how to link to libintl.
+    ENV.append "LDFLAGS", "-lintl" if MacOS.version <= :high_sierra
+
     # iconv is detected during configure process but -liconv is missing
     # from LDFLAGS as of gnu-tar 1.35. Remove once iconv linking works
     # without this. See https://savannah.gnu.org/bugs/?64441.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Mimicking #136880, on High Sierra there are complaints about missing `_libintl_` symbols too. 

Configure also checked for external libintl but did not add this LDFLAG. Seeing this formula built fine on newest macOSes, it's probably the system's `libiconv` being too old.

Or is it a bug just like #136880?